### PR TITLE
do not need runtime.GOMAXPROCS after go1.5

### DIFF
--- a/cmd/gaea/main.go
+++ b/cmd/gaea/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
 
@@ -33,7 +32,6 @@ import (
 var configFile = flag.String("config", "etc/gaea.ini", "gaea config file")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
 	fmt.Printf("Git commit:%s\n", core.Version)
 	fmt.Printf("Build time:%s\n", core.Compile)


### PR DESCRIPTION
By default, Go programs run with GOMAXPROCS set to the number of cores available after go1.5.