### PR TITLE
Fix column case sensitive issue

### DIFF
--- a/proxy/plan/plan_delete_test.go
+++ b/proxy/plan/plan_delete_test.go
@@ -59,6 +59,15 @@ func TestMycatShardDeleteWithWhere(t *testing.T) {
 				},
 			},
 		},
+		{ // column should be case insensitive
+			db:  "db_mycat",
+			sql: "delete from tbl_mycat where ID = 0",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"DELETE FROM `tbl_mycat` WHERE `ID`=0"},
+				},
+			},
+		},
 		{
 			db:  "db_mycat",
 			sql: "delete from tbl_mycat where id = 1",

--- a/proxy/plan/plan_insert.go
+++ b/proxy/plan/plan_insert.go
@@ -176,7 +176,7 @@ func handleInsertColumnNames(p *InsertPlan) error {
 		for i, assignment := range p.stmt.Setlist {
 			col := assignment.Column
 			removeSchemaAndTableInfoInColumnName(col)
-			columnName := col.Name.String()
+			columnName := col.Name.L
 			rule := p.tableRules[p.table]
 			if columnName == rule.GetShardingColumn() {
 				p.shardingColumnIndex = i
@@ -186,7 +186,7 @@ func handleInsertColumnNames(p *InsertPlan) error {
 		// INSERT INTO tbl (col, ...) VALUES (val, ...)
 		for i, col := range p.stmt.Columns {
 			removeSchemaAndTableInfoInColumnName(col)
-			columnName := col.Name.String()
+			columnName := col.Name.L
 			rule := p.tableRules[p.table]
 			if columnName == rule.GetShardingColumn() {
 				p.shardingColumnIndex = i
@@ -265,7 +265,7 @@ func handleInsertOnDuplicate(p *InsertPlan) error {
 
 	shardingColumnName := p.tableRules[p.table].GetShardingColumn()
 	for _, a := range p.stmt.OnDuplicate {
-		if a.Column.Name.String() == shardingColumnName {
+		if a.Column.Name.L == shardingColumnName {
 			return errors.ErrUpdateKey
 		}
 		removeSchemaAndTableInfoInColumnName(a.Column)

--- a/proxy/plan/plan_insert.go
+++ b/proxy/plan/plan_insert.go
@@ -285,7 +285,7 @@ func handleInsertGlobalSequenceValue(p *InsertPlan) error {
 	// not assignment mode
 	if p.isAssignmentMode {
 		for _, assignment := range p.stmt.Setlist {
-			columnName := assignment.Column.Name.String()
+			columnName := assignment.Column.Name.L
 			if columnName == pkName {
 				if x, ok := assignment.Expr.(*ast.FuncCallExpr); ok {
 					if x.FnName.L == "nextval" {

--- a/proxy/plan/plan_insert.go
+++ b/proxy/plan/plan_insert.go
@@ -305,7 +305,7 @@ func handleInsertGlobalSequenceValue(p *InsertPlan) error {
 	// not assignment mode
 	var seqIndex = -1
 	for i, column := range p.stmt.Columns {
-		columnName := column.Name.String()
+		columnName := column.Name.L
 		if columnName == pkName {
 			seqIndex = i
 			break

--- a/proxy/plan/plan_insert_test.go
+++ b/proxy/plan/plan_insert_test.go
@@ -734,3 +734,39 @@ func TestEscapeBackslashShard(t *testing.T) {
 		t.Run(test.sql, getTestFunc(ns, test))
 	}
 }
+
+func TestMycatShardSimpleInsertColumnCaseInsensitive(t *testing.T) {
+	ns, err := preparePlanInfo()
+	if err != nil {
+		t.Fatalf("prepare namespace error: %v", err)
+	}
+
+	tests := []SQLTestcase{
+		{
+			db:  "db_mycat",
+			sql: "insert into tbl_mycat (ID, a) values (0, 'hi')",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"INSERT INTO `tbl_mycat` (`ID`,`a`) VALUES (0,'hi')"},
+				},
+			},
+		},
+		{
+			db:  "db_mycat",
+			sql: "insert into tbl_mycat set ID = 0, a = 'hi'",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"INSERT INTO `tbl_mycat` SET `ID`=0,`a`='hi'"},
+				},
+			},
+		},
+		{
+			db:     "db_mycat",
+			sql:    "insert into tbl_mycat (ID, a) values (6, 'hi') on duplicate key update ID = 5",
+			hasErr: true, // routing key in update expression
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.sql, getTestFunc(ns, test))
+	}
+}

--- a/proxy/plan/plan_insert_test.go
+++ b/proxy/plan/plan_insert_test.go
@@ -666,6 +666,15 @@ func TestMycatInsertSequenceShardKey(t *testing.T) {
 				},
 			},
 		},
+		{
+			db:  "db_mycat",
+			sql: "insert into tbl_mycat (ID, a) values (nextval(), 'hi')",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"INSERT INTO `tbl_mycat` (`ID`,`a`) VALUES (4,'hi')"},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.sql, getTestFunc(ns, test))

--- a/proxy/plan/plan_insert_test.go
+++ b/proxy/plan/plan_insert_test.go
@@ -675,6 +675,15 @@ func TestMycatInsertSequenceShardKey(t *testing.T) {
 				},
 			},
 		},
+		{
+			db:  "db_mycat",
+			sql: "insert into tbl_mycat set ID = nextval(), a = 'hi'",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_1": {"INSERT INTO `tbl_mycat` SET `ID`=5,`a`='hi'"},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.sql, getTestFunc(ns, test))

--- a/proxy/plan/plan_select.go
+++ b/proxy/plan/plan_select.go
@@ -971,5 +971,5 @@ func getTableInfoFromTableName(t *ast.TableName) (string, string) {
 }
 
 func getColumnInfoFromColumnName(t *ast.ColumnName) (string, string, string) {
-	return t.Schema.O, t.Table.O, t.Name.O
+	return t.Schema.O, t.Table.O, t.Name.L
 }

--- a/proxy/plan/plan_select.go
+++ b/proxy/plan/plan_select.go
@@ -893,7 +893,7 @@ func handleBinaryOperationExprCompareLeftColumnRightValue(p *TableAliasStmtInfo,
 		return false, nil, nil, fmt.Errorf("get ValueExpr value error: %v", err)
 	}
 
-	tableIndexes, err := findTableIndexes(rule, column.Name.Name.String(), v)
+	tableIndexes, err := findTableIndexes(rule, column.Name.Name.L, v)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("find table index error: %v", err)
 	}
@@ -924,7 +924,7 @@ func handleBinaryOperationExprCompareLeftValueRightColumn(p *TableAliasStmtInfo,
 		return false, nil, nil, fmt.Errorf("get ValueExpr value error: %v", err)
 	}
 
-	tableIndexes, err := findTableIndexes(rule, column.Name.Name.String(), v)
+	tableIndexes, err := findTableIndexes(rule, column.Name.Name.L, v)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("find table index error: %v", err)
 	}

--- a/proxy/plan/plan_select_test.go
+++ b/proxy/plan/plan_select_test.go
@@ -739,7 +739,6 @@ func TestKingshardSelectAlias(t *testing.T) {
 	}
 }
 
-
 func TestKingshardSelectBetweenAlias(t *testing.T) {
 	ns, err := preparePlanInfo()
 	if err != nil {
@@ -761,6 +760,42 @@ func TestKingshardSelectBetweenAlias(t *testing.T) {
 					"db_ks": {
 						"SELECT `name` FROM `tbl_ks_0002` AS `a` WHERE `a`.`id` BETWEEN 10 AND 100",
 						"SELECT `name` FROM `tbl_ks_0003` AS `a` WHERE `a`.`id` BETWEEN 10 AND 100",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.sql, getTestFunc(ns, test))
+	}
+}
+
+func TestKingshardSelectColumnCaseInsensitive(t *testing.T) {
+	ns, err := preparePlanInfo()
+	if err != nil {
+		t.Fatalf("prepare namespace error: %v", err)
+	}
+
+	tests := []SQLTestcase{
+		{
+			db:  "db_ks",
+			sql: "select a.ss, a from tbl_ks as a where a.ID = 1",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `a`.`ss`,`a` FROM `tbl_ks_0001` AS `a` WHERE `a`.`ID`=1",
+					},
+				},
+			},
+		},
+		{
+			db:  "db_ks",
+			sql: "select a.ss, a from tbl_ks as a where 1 = a.ID",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `a`.`ss`,`a` FROM `tbl_ks_0001` AS `a` WHERE 1=`a`.`ID`",
 					},
 				},
 			},

--- a/proxy/plan/plan_select_test.go
+++ b/proxy/plan/plan_select_test.go
@@ -771,7 +771,7 @@ func TestKingshardSelectBetweenAlias(t *testing.T) {
 	}
 }
 
-func TestKingshardSelectColumnCaseInsensitive(t *testing.T) {
+func TestSelectColumnCaseInsensitive(t *testing.T) {
 	ns, err := preparePlanInfo()
 	if err != nil {
 		t.Fatalf("prepare namespace error: %v", err)
@@ -797,6 +797,34 @@ func TestKingshardSelectColumnCaseInsensitive(t *testing.T) {
 					"db_ks": {
 						"SELECT `a`.`ss`,`a` FROM `tbl_ks_0001` AS `a` WHERE 1=`a`.`ID`",
 					},
+				},
+			},
+		},
+		{
+			db:  "db_ks",
+			sql: "select * from tbl_ks_day where CREATE_TIME between '2014-09-05 00:00:00' and '2014-09-07 00:00:00'", // 2014-09-01 00:00:00
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT * FROM `tbl_ks_day_20140905` WHERE `CREATE_TIME` BETWEEN '2014-09-05 00:00:00' AND '2014-09-07 00:00:00'",
+					},
+				},
+				"slice-1": {
+					"db_ks": {
+						"SELECT * FROM `tbl_ks_day_20140907` WHERE `CREATE_TIME` BETWEEN '2014-09-05 00:00:00' AND '2014-09-07 00:00:00'",
+					},
+				},
+			},
+		},
+		{
+			db:  "db_mycat",
+			sql: "select * from tbl_mycat where ID in (0,2)",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"SELECT * FROM `tbl_mycat` WHERE `ID` IN (0)"},
+				},
+				"slice-1": {
+					"db_mycat_2": {"SELECT * FROM `tbl_mycat` WHERE `ID` IN (2)"},
 				},
 			},
 		},

--- a/proxy/plan/plan_update.go
+++ b/proxy/plan/plan_update.go
@@ -169,7 +169,7 @@ func handleUpdateAssignmentList(p *UpdatePlan) error {
 			return err
 		}
 
-		if need && r.GetShardingColumn() == assignment.Column.Name.String() {
+		if need && r.GetShardingColumn() == assignment.Column.Name.L {
 			return fmt.Errorf("cannot update shard column value")
 		}
 		removeSchemaAndTableInfoInColumnName(assignment.Column)

--- a/proxy/plan/plan_update_test.go
+++ b/proxy/plan/plan_update_test.go
@@ -44,8 +44,49 @@ func TestMycatShardSimpleUpdate(t *testing.T) {
 		},
 		{
 			db:     "db_mycat",
+			sql:    "update tbl_mycat set ID = 5",
+			hasErr: true, // cannot update shard column value
+		},
+		{
+			db:  "db_mycat",
+			sql: "update tbl_mycat set a = 'hi' where ID = 5",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_1": {"UPDATE `tbl_mycat` SET `a`='hi' WHERE `ID`=5"},
+				},
+			},
+		},
+		{
+			db:     "db_mycat",
 			sql:    "update tbl_mycat, tbl_mycat_child set id = 5",
 			hasErr: true, // does not support update multiple tables in sharding
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.sql, getTestFunc(ns, test))
+	}
+}
+
+func TestMycatShardUpdateColumnCaseInsensitive(t *testing.T) {
+	ns, err := preparePlanInfo()
+	if err != nil {
+		t.Fatalf("prepare namespace error: %v", err)
+	}
+
+	tests := []SQLTestcase{
+		{
+			db:     "db_mycat",
+			sql:    "update tbl_mycat set ID = 5",
+			hasErr: true, // cannot update shard column value
+		},
+		{
+			db:  "db_mycat",
+			sql: "update tbl_mycat set a = 'hi' where ID = 5",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_1": {"UPDATE `tbl_mycat` SET `a`='hi' WHERE `ID`=5"},
+				},
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
This PR fixed the column name case sensitive issue, which generated wrong plan for sharding tables.

According to[ MySQL doc](https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html), column/column aliases are not case sensitive.

    Column, index, stored routine, and event names are not case sensitive on any platform, nor are 
    column aliases.

