### PR TITLE
时间分片增加snowflake类型字段

### DIFF
--- a/models/shard.go
+++ b/models/shard.go
@@ -59,6 +59,11 @@ type Shard struct {
 	ParentTable   string   `json:"parent_table"`
 	Type          string   `json:"type"` // 表类型: 包括分表如hash/range/data,关联表如: linked 全局表如: global等
 	Key           string   `json:"key"`
+
+	IsSnowflakeKey     bool   `json:"is_snowflake_key"`     // 是否是snowflake格式字段
+	SnowflakeEpoch     uint64 `json:"snowflake_epoch"`      // snowflake起始时间戳（豪秒）
+	SnowflakeTimeShift uint8   `json:"snowflake_time_shift"` // 时间戳偏移量
+
 	Locations     []int    `json:"locations"`
 	Slices        []string `json:"slices"`
 	DateRange     []string `json:"date_range"`


### PR DESCRIPTION
麻烦大佬花两分钟时间看下。

我有个分表需求，表的主键是snowflake算法生成的ID，我想基于这个ID做时间分表，同时又能满足基于主键做查询和修改的需求，于是就有了以下改动，不敢轻易上线，麻烦大佬帮看下。

-------------------------
由于存在历史数据，迁移起来太麻烦，还得停服务，所以想旧数据不动，设置起始分片值A，让大于值A的ID才走分片规则，否者就对默认表进行操作，由于还没搞明白这个项目，不知道该怎么入手，望指点。