### PR TITLE
make table name case insensitive

### DIFF
--- a/proxy/plan/plan_insert.go
+++ b/proxy/plan/plan_insert.go
@@ -135,7 +135,7 @@ func handleInsertTableRefs(p *InsertPlan) (fastReturn bool, err error) {
 		return false, fmt.Errorf("not a table source")
 	}
 	tableName := tableSource.Source.(*ast.TableName)
-	p.table = tableName.Name.String()
+	p.table = tableName.Name.L
 
 	rule, need, err := NeedCreateTableNameDecoratorWithoutAlias(p.StmtInfo, tableName)
 	if err != nil {

--- a/proxy/plan/plan_insert_test.go
+++ b/proxy/plan/plan_insert_test.go
@@ -789,7 +789,7 @@ func TestMycatShardSimpleInsertColumnCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestMycatShardSimpleInserTableNameColumnCaseInsensitive(t *testing.T) {
+func TestInserTableNameColumnCaseInsensitive(t *testing.T) {
 	ns, err := preparePlanInfo()
 	if err != nil {
 		t.Fatalf("prepare namespace error: %v", err)
@@ -802,6 +802,15 @@ func TestMycatShardSimpleInserTableNameColumnCaseInsensitive(t *testing.T) {
 			sqls: map[string]map[string][]string{
 				"slice-0": {
 					"db_mycat_0": {"INSERT INTO `TBL_MYCAT` (`ID`,`a`) VALUES (0,'hi')"},
+				},
+			},
+		},
+		{
+			db:  "db_ks",
+			sql: "insert into tbl_ks_uppercase_child (ID, a) values (0, 'hi')",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {"INSERT INTO `tbl_ks_uppercase_child_0000` (`ID`,`a`) VALUES (0,'hi')"},
 				},
 			},
 		},

--- a/proxy/plan/plan_insert_test.go
+++ b/proxy/plan/plan_insert_test.go
@@ -788,3 +788,25 @@ func TestMycatShardSimpleInsertColumnCaseInsensitive(t *testing.T) {
 		t.Run(test.sql, getTestFunc(ns, test))
 	}
 }
+
+func TestMycatShardSimpleInserTableNameColumnCaseInsensitive(t *testing.T) {
+	ns, err := preparePlanInfo()
+	if err != nil {
+		t.Fatalf("prepare namespace error: %v", err)
+	}
+
+	tests := []SQLTestcase{
+		{
+			db:  "db_mycat",
+			sql: "insert into TBL_MYCAT (ID, a) values (0, 'hi')",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"INSERT INTO `TBL_MYCAT` (`ID`,`a`) VALUES (0,'hi')"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.sql, getTestFunc(ns, test))
+	}
+}

--- a/proxy/plan/plan_select.go
+++ b/proxy/plan/plan_select.go
@@ -402,7 +402,7 @@ func rewriteTableSource(p *TableAliasStmtInfo, tableSource *ast.TableSource) err
 		if err := handleSubquerySelectStmt(p, ss); err != nil {
 			return fmt.Errorf("handleSubquerySelectStmt error: %v", err)
 		}
-		alias := tableSource.AsName.String()
+		alias := tableSource.AsName.L
 		if alias != "" {
 			if _, err := p.RecordSubqueryTableAlias(alias); err != nil {
 				return fmt.Errorf("record subquery alias error: %v", err)
@@ -419,7 +419,7 @@ func rewriteTableNameInTableSource(p *TableAliasStmtInfo, tableSource *ast.Table
 	if !ok {
 		return fmt.Errorf("field Source is not type of TableName, type: %T", tableSource.Source)
 	}
-	alias := tableSource.AsName.String()
+	alias := tableSource.AsName.L
 
 	rule, need, err := NeedCreateTableNameDecorator(p, tableName, alias)
 	if err != nil {
@@ -967,9 +967,9 @@ func handleLimit(p *SelectPlan, stmt *ast.SelectStmt) error {
 }
 
 func getTableInfoFromTableName(t *ast.TableName) (string, string) {
-	return t.Schema.O, t.Name.O
+	return t.Schema.O, t.Name.L
 }
 
 func getColumnInfoFromColumnName(t *ast.ColumnName) (string, string, string) {
-	return t.Schema.O, t.Table.O, t.Name.L
+	return t.Schema.O, t.Table.L, t.Name.L
 }

--- a/proxy/plan/plan_select_test.go
+++ b/proxy/plan/plan_select_test.go
@@ -876,6 +876,17 @@ func TestSelectTableNameCaseInsensitive(t *testing.T) {
 			},
 		},
 		{
+			db:  "db_ks",
+			sql: "select a.ss, a from tbl_ks_uppercase_child as a where a.id = 1",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `a`.`ss`,`a` FROM `tbl_ks_uppercase_child_0001` AS `a` WHERE `a`.`id`=1",
+					},
+				},
+			},
+		},
+		{
 			db:  "db_mycat",
 			sql: "select * from TBL_MYCAT where TBL_MYCAT.ID in (0,2)",
 			sqls: map[string]map[string][]string{

--- a/proxy/plan/plan_select_test.go
+++ b/proxy/plan/plan_select_test.go
@@ -835,6 +835,89 @@ func TestSelectColumnCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestSelectTableNameCaseInsensitive(t *testing.T) {
+	ns, err := preparePlanInfo()
+	if err != nil {
+		t.Fatalf("prepare namespace error: %v", err)
+	}
+
+	tests := []SQLTestcase{
+		{
+			db:  "db_ks",
+			sql: "select a.ss, a from TBL_KS_UPPERCASE as a where a.id = 1",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `a`.`ss`,`a` FROM `TBL_KS_UPPERCASE_0001` AS `a` WHERE `a`.`id`=1",
+					},
+				},
+			},
+		},
+		{
+			db:  "db_ks",
+			sql: "select ss, a from TBL_KS_UPPERCASE where id = 1",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `ss`,`a` FROM `TBL_KS_UPPERCASE_0001` WHERE `id`=1",
+					},
+				},
+			},
+		},
+		{
+			db:  "db_ks",
+			sql: "select a.ss, a from tbl_ks_uppercase as a where a.id = 1",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_ks": {
+						"SELECT `a`.`ss`,`a` FROM `tbl_ks_uppercase_0001` AS `a` WHERE `a`.`id`=1",
+					},
+				},
+			},
+		},
+		{
+			db:  "db_mycat",
+			sql: "select * from TBL_MYCAT where TBL_MYCAT.ID in (0,2)",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"SELECT * FROM `TBL_MYCAT` WHERE `TBL_MYCAT`.`ID` IN (0)"},
+				},
+				"slice-1": {
+					"db_mycat_2": {"SELECT * FROM `TBL_MYCAT` WHERE `TBL_MYCAT`.`ID` IN (2)"},
+				},
+			},
+		},
+		{
+			db:  "db_mycat",
+			sql: "select * from tbl_mycat as A where A.ID in (0,2)",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"SELECT * FROM `tbl_mycat` AS `A` WHERE `A`.`ID` IN (0)"},
+				},
+				"slice-1": {
+					"db_mycat_2": {"SELECT * FROM `tbl_mycat` AS `A` WHERE `A`.`ID` IN (2)"},
+				},
+			},
+		},
+		{
+			db:  "db_mycat",
+			sql: "select * from (select id, ss from tbl_mycat) A where A.ID in (0,2)",
+			sqls: map[string]map[string][]string{
+				"slice-0": {
+					"db_mycat_0": {"SELECT * FROM (SELECT `id`,`ss` FROM (`tbl_mycat`)) AS `A` WHERE `A`.`ID` IN (0)"},
+				},
+				"slice-1": {
+					"db_mycat_2": {"SELECT * FROM (SELECT `id`,`ss` FROM (`tbl_mycat`)) AS `A` WHERE `A`.`ID` IN (2)"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.sql, getTestFunc(ns, test))
+	}
+}
+
 // TODO: range shard
 func TestMycatSelectBinaryOperatorComparison(t *testing.T) {
 	ns, err := preparePlanInfo()

--- a/proxy/plan/plan_test.go
+++ b/proxy/plan/plan_test.go
@@ -305,7 +305,21 @@ func preparePlanInfo() (*PlanInfo, error) {
 				"20140901-20140905",
 				"20140907-20140908"
 			]
-		},
+        },
+        {
+            "db": "db_ks",
+            "table": "TBL_KS_UPPERCASE",
+            "type": "mod",
+            "key": "id",
+            "locations": [
+                2,
+                2
+            ],
+            "slices": [
+                "slice-0",
+                "slice-1"
+            ]
+        },
         {
             "db": "db_mycat",
             "table": "tbl_mycat",

--- a/proxy/plan/plan_test.go
+++ b/proxy/plan/plan_test.go
@@ -321,6 +321,13 @@ func preparePlanInfo() (*PlanInfo, error) {
             ]
         },
         {
+            "db": "db_ks",
+            "table": "TBL_KS_UPPERCASE_CHILD",
+            "type": "linked",
+            "key": "ID",
+            "parent_table": "TBL_KS_UPPERCASE"
+        },
+        {
             "db": "db_mycat",
             "table": "tbl_mycat",
             "type": "mycat_mod",

--- a/proxy/router/rule.go
+++ b/proxy/router/rule.go
@@ -275,7 +275,7 @@ func createLinkedRule(rules map[string]map[string]Rule, shard *models.Shard) (*L
 	if !ok {
 		return nil, fmt.Errorf("db of LinkedRule is not found in parent rules")
 	}
-	dbRule, ok := tableRules[shard.ParentTable]
+	dbRule, ok := tableRules[strings.ToLower(shard.ParentTable)]
 	if !ok {
 		return nil, fmt.Errorf("parent table of LinkedRule is not found in parent rules")
 	}
@@ -289,8 +289,8 @@ func createLinkedRule(rules map[string]map[string]Rule, shard *models.Shard) (*L
 
 	linkedRule := &LinkedRule{
 		db:             shard.DB,
-		table:          shard.Table,
-		shardingColumn: shard.Key,
+		table:          strings.ToLower(shard.Table),
+		shardingColumn: strings.ToLower(shard.Key),
 		linkToRule:     linkToRule,
 	}
 

--- a/proxy/router/rule.go
+++ b/proxy/router/rule.go
@@ -300,7 +300,7 @@ func createLinkedRule(rules map[string]map[string]Rule, shard *models.Shard) (*L
 func parseRule(cfg *models.Shard) (*BaseRule, error) {
 	r := new(BaseRule)
 	r.db = cfg.DB
-	r.table = cfg.Table
+	r.table = strings.ToLower(cfg.Table)
 	r.shardingColumn = strings.ToLower(cfg.Key) //ignore case
 	r.ruleType = cfg.Type
 	r.slices = cfg.Slices //将rule model中的slices赋值给rule


### PR DESCRIPTION
This PR makes the table name case in-sensitive in shard configuration.
It's not a breaking change, because the table name is not case-sensitive either now, in most case.


Normally, database name is in configuration,  and is not hard-coded in source code. To make database name case in-sensitive, more efforts would be involved. We just leave it unchanged now.