### PR TITLE
catch errors from mysql

### DIFF
--- a/backend/direct_connection.go
+++ b/backend/direct_connection.go
@@ -156,7 +156,6 @@ func (dc *DirectConnection) IsClosed() bool {
 func (dc *DirectConnection) readPacket() ([]byte, error) {
 	data, err := dc.conn.ReadPacket()
 	dc.pkgErr = err
-
 	return data, err
 }
 
@@ -750,6 +749,7 @@ func (dc *DirectConnection) readResult(binary bool) (*mysql.Result, error) {
 	} else if data[0] == mysql.LocalInFileHeader {
 		return nil, mysql.ErrMalformPacket
 	}
+
 	return dc.readResultset(data, binary)
 }
 


### PR DESCRIPTION
```
for {
		data, err = dc.readPacket()  
		// EOF Packet
		if dc.isEOFPacket(data) {
          
                }
                // TODO handle error package
}
```
从mysql 读取行数据时, 如果没有处理返回的错误, 会导致read过程阻塞在下次循环的readPacket() 
