### PR TITLE
fix writeFieldList cause broken pipe

### DIFF
--- a/proxy/server/client_conn.go
+++ b/proxy/server/client_conn.go
@@ -330,7 +330,7 @@ func (cc *ClientConn) writeColumnDefinition(field *mysql.Field) error {
 		1 + // decimals
 		2 // filler
 	if field.DefaultValue != nil {
-		length += mysql.LenEncIntSize(uint64(len(field.DefaultValue))) + len(field.DefaultValue)
+		length += 8 + len(field.DefaultValue)
 	}
 
 	data := cc.StartEphemeralPacket(length)
@@ -366,7 +366,7 @@ func (cc *ClientConn) writeColumnDefinition(field *mysql.Field) error {
 	pos = mysql.WriteUint16(data, pos, uint16(0x0000))
 
 	if field.DefaultValue != nil {
-		pos = mysql.WriteLenEncInt(data, pos, field.DefaultValueLength)
+		pos = mysql.WriteUint64(data, pos, field.DefaultValueLength)
 		copy(data[pos:], field.DefaultValue)
 		pos += len(field.DefaultValue)
 	}


### PR DESCRIPTION
关联到 #163 。这里参考Field中Dump()方法，不做其他改变，依然使用缓冲池。经过验证，可以解决issue中描述的问题。原因是客户端读取包异常，造成连接主动断开。