### PR TITLE
fix: check `err != nil` but return a nil value error `errRet`

### DIFF
--- a/proxy/server/executor_handle.go
+++ b/proxy/server/executor_handle.go
@@ -137,7 +137,7 @@ func (se *SessionExecutor) doMultiStmts(reqCtx *util.RequestContext, sql string)
 			if err = se.session.writeResponse(response); err != nil {
 				log.Warn("session write response error, error: %v", err)
 				se.session.Close()
-				return r, errRet
+				return r, err
 			}
 		}
 	}


### PR DESCRIPTION

errRet 已经在前面检查了，所以这里一定是 nil，这样直接return 肯定会导致for 循环没执行完，所以这里的本意我认为应该返回 err

I have an idea to detect code that returns a non-relevant nilness error bug. I checked the top 1000 GitHub Go repositories and found this, all result listed in https://github.com/alingse/sundrylint/issues/4