### PR TITLE
fix: goroutine WaitGroup race in test

### DIFF
--- a/proxy/server/session_test.go
+++ b/proxy/server/session_test.go
@@ -173,8 +173,8 @@ func TestSessionRunInTxNamespaceChangedWithMock(t *testing.T) {
 			seList[i] = se
 		}
 		for _, se := range seList {
+			g.Add(1)
 			go func(se *SessionExecutor) {
-				g.Add(1)
 				defer g.Done()
 				se.ksConns = make(map[string]backend.PooledConnect)
 				se.status = se.status | mysql.ServerStatusInTrans


### PR DESCRIPTION
It's unlikely to get a race condition given the `time.Sleep(time.Millisecond * 50)` call before `g.Wait()`, but nonetheless this should be fixed.