### PR TITLE
fix: simplify returning boolean expression

### DIFF
--- a/proxy/plan/plan_unshard.go
+++ b/proxy/plan/plan_unshard.go
@@ -82,11 +82,7 @@ func IsSelectLastInsertIDStmt(stmt ast.StmtNode) bool {
 // IsSetStmt check if the statement is set comment
 func IsSetStmt(stmt ast.StmtNode) bool {
 	_, ok := stmt.(*ast.SetStmt)
-	if !ok {
-		return false
-	}
-
-	return true
+	return ok
 }
 
 // CreateUnshardPlan constructor of UnshardPlan


### PR DESCRIPTION
It's simpler to just return the boolean.